### PR TITLE
Fuzzy linkage tests improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
                 source ${GITHUB_WORKSPACE}/github_action_scripts/set_crate_docker_environment
                 ${GITHUB_WORKSPACE}/github_action_scripts/installer_setup.sh
                 cd ${HOME}
-                curl -L --retry 10 --fail https://github.com/RudolfCardinal/crate/releases/latest/download/installer.sh --output crate_docker_installer.sh
+                curl -L --retry 10 --fail https://github.com/ucam-department-of-psychiatry/crate/releases/latest/download/installer.sh --output crate_docker_installer.sh
                 chmod u+x crate_docker_installer.sh
                 ./crate_docker_installer.sh
                 export CRATE_HOME=${HOME}/crate

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,11 @@ Clinical Records Anonymisation and Text Extraction (CRATE)
 Purpose
 -------
 
+Create and use de-identified databases for research.
+
 - Anonymises relational databases.
+
+- Extracts and de-identifies text from associated binary files.
 
 - Performs some specific preprocessing tasks; e.g.
 
@@ -18,12 +22,16 @@ Purpose
     some databases (e.g. TPP SystmOne);
   - fetches some word lists, e.g. forenames/surnames/eponyms.
 
+- Provides tools to link databases, including via Bayesian personal identity
+  matching, in identifiable or de-identified fashion.
+
 - Provides a natural language processing (NLP) pipeline.
 
 - Web app for
 
-  - querying the anonymised database
-  - managing a consent-to-contact process
+  - querying the anonymised database;
+  - providing a de-identification API;
+  - managing a consent-to-contact process.
 
 
 Documentation
@@ -36,7 +44,7 @@ Sources
 -------
 
 - Python package: https://pypi.org/project/crate-anon/
-- Source code: https://github.com/RudolfCardinal/crate
+- Source code: https://github.com/ucam-department-of-psychiatry/crate
 
 
 Licence

--- a/crate_anon/linkage/tests/fuzzy_id_match_tests.py
+++ b/crate_anon/linkage/tests/fuzzy_id_match_tests.py
@@ -62,6 +62,7 @@ from crate_anon.linkage.frequencies import (
 from crate_anon.linkage.identifiers import (
     DateOfBirth,
     DummyLetterIdentifier,
+    DummyLetterTemporalIdentifier,
     Forename,
     gen_best_comparisons,
     Gender,
@@ -1506,6 +1507,26 @@ class UnorderedMultipleComparisonTests(MultipleComparisonTestBase):
         self.assertAlmostEqual(
             correction.log_likelihood_ratio, -ln(3), delta=self.DELTA
         )
+
+    def test_with_incomparable_identifiers(self) -> None:
+        """
+        Use identifiers that aren't allowed to be compared, e.g. names with
+        non-overlapping timestamps. This will give a comparison that is
+        ``None``, and make the code coverage checks happy.
+
+        .. code-block:: bash
+
+            pip install pytest-cov
+            pytest --cov --cov-report html
+        """
+        a_early = DummyLetterTemporalIdentifier(
+            value="A", start_date="1900-01-01", end_date="1900-12-31"
+        )
+        a_late = DummyLetterTemporalIdentifier(
+            value="A", start_date="2000-01-01", end_date="2000-12-31"
+        )
+        result = self.compare([a_early], [a_late])
+        self.assertEqual(len(result), 0)  # no comparisons
 
 
 class OrderedMultipleComparisonTests(MultipleComparisonTestBase):

--- a/crate_anon/linkage/tests/fuzzy_id_match_tests.py
+++ b/crate_anon/linkage/tests/fuzzy_id_match_tests.py
@@ -804,17 +804,17 @@ class FuzzyLinkageTests(unittest.TestCase):
             f = cfg.get_surname_freq_info(surname)
             log.info(f"Surname frequency for {surname}: {f}")
 
-            self.assertTrue(isinstance(f.name, str))
-            self.assertTrue(isinstance(f.gender, str))
-            self.assertTrue(isinstance(f.p_name, float))
+            self.assertIsInstance(f.name, str)
+            self.assertIsInstance(f.gender, str)
+            self.assertIsInstance(f.p_name, float)
 
-            self.assertTrue(isinstance(f.metaphone, str))
-            self.assertTrue(isinstance(f.p_metaphone, float))
-            self.assertTrue(isinstance(f.p_metaphone_not_name, float))
+            self.assertIsInstance(f.metaphone, str)
+            self.assertIsInstance(f.p_metaphone, float)
+            self.assertIsInstance(f.p_metaphone_not_name, float)
 
-            self.assertTrue(isinstance(f.f2c, str))
-            self.assertTrue(isinstance(f.p_f2c, float))
-            self.assertTrue(isinstance(f.p_f2c_not_name_metaphone, float))
+            self.assertIsInstance(f.f2c, str)
+            self.assertIsInstance(f.p_f2c, float)
+            self.assertIsInstance(f.p_f2c_not_name_metaphone, float)
 
         for forename, gender in [
             ("James", GENDER_MALE),
@@ -833,17 +833,17 @@ class FuzzyLinkageTests(unittest.TestCase):
             log.info(
                 f"Forename frequency for {forename}, gender {gender}: {f}"
             )
-            self.assertTrue(isinstance(f.name, str))
-            self.assertTrue(isinstance(f.gender, str))
-            self.assertTrue(isinstance(f.p_name, float))
+            self.assertIsInstance(f.name, str)
+            self.assertIsInstance(f.gender, str)
+            self.assertIsInstance(f.p_name, float)
 
-            self.assertTrue(isinstance(f.metaphone, str))
-            self.assertTrue(isinstance(f.p_metaphone, float))
-            self.assertTrue(isinstance(f.p_metaphone_not_name, float))
+            self.assertIsInstance(f.metaphone, str)
+            self.assertIsInstance(f.p_metaphone, float)
+            self.assertIsInstance(f.p_metaphone_not_name, float)
 
-            self.assertTrue(isinstance(f.f2c, str))
-            self.assertTrue(isinstance(f.p_f2c, float))
-            self.assertTrue(isinstance(f.p_f2c_not_name_metaphone, float))
+            self.assertIsInstance(f.f2c, str)
+            self.assertIsInstance(f.p_f2c, float)
+            self.assertIsInstance(f.p_f2c_not_name_metaphone, float)
 
     def test_fuzzy_linkage_frequencies_postcode(self) -> None:
         cfg = self.cfg

--- a/crate_anon/linkage/tests/fuzzy_id_match_tests.py
+++ b/crate_anon/linkage/tests/fuzzy_id_match_tests.py
@@ -42,9 +42,9 @@ from pendulum import Date
 
 from crate_anon.linkage.comparison import (
     AdjustLogOddsComparison,
+    Comparison,
     DirectComparison,
 )
-
 from crate_anon.linkage.constants import (
     FuzzyDefaults,
     GENDER_FEMALE,
@@ -1399,11 +1399,11 @@ class MultipleComparisonTestBase(unittest.TestCase):
 
 
 class UnorderedMultipleComparisonTests(MultipleComparisonTestBase):
+    @staticmethod
     def compare(
-        self,
         proband_identifiers: List[Identifier],
         candidate_identifiers: List[Identifier],
-    ):
+    ) -> List[Comparison]:
         return list(
             gen_best_comparisons(
                 proband_identifiers=proband_identifiers,
@@ -1513,7 +1513,7 @@ class OrderedMultipleComparisonTests(MultipleComparisonTestBase):
         self,
         proband_identifiers: List[Identifier],
         candidate_identifiers: List[Identifier],
-    ):
+    ) -> List[Comparison]:
         return list(
             gen_best_comparisons(
                 proband_identifiers=proband_identifiers,
@@ -1670,6 +1670,8 @@ class OrderedMultipleComparisonTests(MultipleComparisonTestBase):
         d = DummyLetterIdentifier("D")
 
         """
+        Comparing proband [a, b, c] to candidate [b, c, d]:
+
         p = proband index
         c = candidate index
         d = distance
@@ -1688,6 +1690,7 @@ class OrderedMultipleComparisonTests(MultipleComparisonTestBase):
 
         then we sort them by -LLR and distance:
 
+                                        returned?
         b - b  match B     1 0 1  3.2   Yes
         c - c  match C     2 1 1  3.2   Yes
         a - b  mismatch A  0 0 0  -4.5  No (c=0 used)

--- a/crate_anon/linkage/tests/fuzzy_id_match_tests.py
+++ b/crate_anon/linkage/tests/fuzzy_id_match_tests.py
@@ -1421,21 +1421,22 @@ class MultipleComparisonTests(unittest.TestCase):
     # Multiple comparison correction checks
     # -------------------------------------------------------------------------
 
-    def test_multiple_comparisons(self) -> None:
-        a = DummyLetterIdentifier("A")
-        b = DummyLetterIdentifier("B")
-        c = DummyLetterIdentifier("C")
-        d = DummyLetterIdentifier("D")
-
+    def test_unordered_one_one(self) -> None:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # UNORDERED, one/one identifier
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        a = DummyLetterIdentifier("A")
+
         result = self.compare_unordered([a], [a])
         self.assertEqual(len(result), 1)  # ... one match, no correction
 
+    def test_unordered_two_two(self) -> None:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # Unordered, two/two identifiers
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        a = DummyLetterIdentifier("A")
+        b = DummyLetterIdentifier("B")
+
         result = self.compare_unordered([a, b], [a, b])
         self.assertEqual(len(result), 3)  # ... two matches and a correction
         corr = result[-1]
@@ -1445,9 +1446,14 @@ class MultipleComparisonTests(unittest.TestCase):
             corr.log_likelihood_ratio, -ln(2), delta=self.DELTA
         )
 
+    def test_unordered_three_three(self) -> None:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # Unordered, three/three identifiers
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        a = DummyLetterIdentifier("A")
+        b = DummyLetterIdentifier("B")
+        c = DummyLetterIdentifier("C")
+
         result = self.compare_unordered([a, b, c], [a, b, c])
         self.assertEqual(len(result), 4)  # ... three matches and a correction
         corr = result[-1]
@@ -1456,9 +1462,14 @@ class MultipleComparisonTests(unittest.TestCase):
             corr.log_likelihood_ratio, -ln(6), delta=self.DELTA
         )
 
+    def test_unordered_one_three(self) -> None:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # Unordered, one/three identifiers
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        a = DummyLetterIdentifier("A")
+        b = DummyLetterIdentifier("B")
+        c = DummyLetterIdentifier("C")
+
         result = self.compare_unordered([a], [a, b, c])
         self.assertEqual(len(result), 2)  # ... one match and a correction
         corr = result[-1]
@@ -1467,15 +1478,22 @@ class MultipleComparisonTests(unittest.TestCase):
             corr.log_likelihood_ratio, -ln(3), delta=self.DELTA
         )
 
+    def test_ordered_one_one(self) -> None:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # ORDERED, one/one identifier
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        a = DummyLetterIdentifier("A")
+
         result = self.compare_ordered([a], [a])
         self.assertEqual(len(result), 1)  # ... one match, no correction
 
+    def test_ordered_two_two_correct_order(self) -> None:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # Ordered, two/two identifiers, correct order
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        a = DummyLetterIdentifier("A")
+        b = DummyLetterIdentifier("B")
+
         result = self.compare_ordered([a, b], [a, b])
         self.assertEqual(len(result), 3)  # ... two matches and a correction
         corr = result[-1]
@@ -1485,9 +1503,13 @@ class MultipleComparisonTests(unittest.TestCase):
             corr.log_likelihood_ratio, ln(self.P_O), delta=self.DELTA
         )
 
+    def test_ordered_two_two_wrong_order(self) -> None:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # Ordered, two/two identifiers, wrong order
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        a = DummyLetterIdentifier("A")
+        b = DummyLetterIdentifier("B")
+
         result = self.compare_ordered([a, b], [b, a])
         self.assertEqual(len(result), 3)  # ... two matches and a correction
         corr = result[-1]
@@ -1498,9 +1520,14 @@ class MultipleComparisonTests(unittest.TestCase):
             corr.log_likelihood_ratio, ln(self.P_U), delta=self.DELTA
         )
 
+    def test_ordered_three_three_correct_order(self) -> None:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # Ordered, three/three identifiers, correct order
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        a = DummyLetterIdentifier("A")
+        b = DummyLetterIdentifier("B")
+        c = DummyLetterIdentifier("C")
+
         result = self.compare_ordered([a, b, c], [a, b, c])
         self.assertEqual(len(result), 4)  # ... three matches and a correction
         corr = result[-1]
@@ -1510,9 +1537,14 @@ class MultipleComparisonTests(unittest.TestCase):
             corr.log_likelihood_ratio, ln(self.P_O), delta=self.DELTA
         )
 
+    def test_ordered_three_three_wrong_order(self) -> None:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # Ordered, three/three identifiers, wrong order
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        a = DummyLetterIdentifier("A")
+        b = DummyLetterIdentifier("B")
+        c = DummyLetterIdentifier("C")
+
         result = self.compare_ordered([a, b, c], [b, c, a])
         self.assertEqual(len(result), 4)  # ... three matches and a correction
         corr = result[-1]
@@ -1523,9 +1555,15 @@ class MultipleComparisonTests(unittest.TestCase):
             corr.log_likelihood_ratio, ln(self.P_U) - ln(5), delta=self.DELTA
         )
 
+    def test_ordered_three_three_two_match_wrong_order(self) -> None:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # Ordered, three/three identifiers, two match, wrong order
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        a = DummyLetterIdentifier("A")
+        b = DummyLetterIdentifier("B")
+        c = DummyLetterIdentifier("C")
+        d = DummyLetterIdentifier("D")
+
         result = self.compare_ordered([a, b, c], [b, c, d])
         self.assertEqual(len(result), 4)
         # ... three matches (but one will be bad) and a correction
@@ -1536,5 +1574,3 @@ class MultipleComparisonTests(unittest.TestCase):
         self.assertAlmostEqual(
             corr.log_likelihood_ratio, ln(self.P_U) - ln(5), delta=self.DELTA
         )
-
-        # import pdb; pdb.set_trace()

--- a/docs/rebuild_docs.py
+++ b/docs/rebuild_docs.py
@@ -50,16 +50,9 @@ DEST_DIRS = []  # type: List[str]
 
 
 if __name__ == "__main__":
-    main_only_quicksetup_rootlogger()
-    # Remove anything old
-    for destdir in [BUILD_HTML_DIR] + DEST_DIRS:
-        print(f"Deleting directory {destdir!r}")
-        shutil.rmtree(destdir, ignore_errors=True)
-
-    # Build docs
-    print("Making HTML version of documentation")
-    os.chdir(THIS_DIR)
-
+    # -------------------------------------------------------------------------
+    # Arguments
+    # -------------------------------------------------------------------------
     # When running from the GitHub action, it isn't possible to
     # download and build Medex automatically, so we just skip this
     # step.
@@ -77,6 +70,26 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    # -------------------------------------------------------------------------
+    # Logging
+    # -------------------------------------------------------------------------
+    main_only_quicksetup_rootlogger(level=logging.INFO)
+
+    # -------------------------------------------------------------------------
+    # Remove anything old
+    # -------------------------------------------------------------------------
+    for destdir in [BUILD_HTML_DIR] + DEST_DIRS:
+        print(f"Deleting directory {destdir!r}")
+        shutil.rmtree(destdir, ignore_errors=True)
+
+    # Build docs
+    print("Making HTML version of documentation")
+    os.chdir(THIS_DIR)
+
+    # -------------------------------------------------------------------------
+    # Recreate inclusion files
+    # -------------------------------------------------------------------------
+
     recreate_args = [
         "python",
         os.path.join(THIS_DIR, "recreate_inclusion_files.py"),
@@ -85,6 +98,10 @@ if __name__ == "__main__":
     if args.skip_medex:
         recreate_args.append("--skip_medex")
     subprocess.check_call(recreate_args)
+
+    # -------------------------------------------------------------------------
+    # Make HTML docs
+    # -------------------------------------------------------------------------
 
     cmdargs = ["make", "html"]
     if args.warnings_as_errors:
@@ -104,7 +121,10 @@ if __name__ == "__main__":
 
         raise e
 
+    # -------------------------------------------------------------------------
     # Copy
+    # -------------------------------------------------------------------------
+
     for destdir in DEST_DIRS:
         print(f"Copying {BUILD_HTML_DIR!r} -> {destdir!r}")
         shutil.copytree(BUILD_HTML_DIR, destdir)

--- a/docs/recreate_inclusion_files.py
+++ b/docs/recreate_inclusion_files.py
@@ -606,5 +606,5 @@ SOLUTION:
 
 
 if __name__ == "__main__":
-    main_only_quicksetup_rootlogger()
+    main_only_quicksetup_rootlogger(level=logging.INFO)
     main()

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1531,12 +1531,12 @@ Changes
   - Document defaults for ``anonymise_numbers_at_word_boundaries_only`` and
     ``anonymise_numbers_at_numeric_boundaries_only`` arguments to
     :class:`crate_anon.anonymise.scrub.PersonalizedScrubber`, fixing
-    https://github.com/RudolfCardinal/crate/issues/67. Add
+    https://github.com/ucam-department-of-psychiatry/crate/issues/67. Add
     ``anonymise_codes_at_numeric_boundaries_only`` option for coherence.
 
   - Document behaviour of ``anonymise_strings_at_word_boundaries_only`` for
     FlashText-based wordlist scrubbing (controlled by ``denylist_use_regex``),
-    fixing https://github.com/RudolfCardinal/crate/issues/68.
+    fixing https://github.com/ucam-department-of-psychiatry/crate/issues/68.
 
   - Default for :ref:`min_string_length_for_errors
     <min_string_length_for_errors>` changed from 1 to 3.

--- a/docs/source/installation/docker.rst
+++ b/docs/source/installation/docker.rst
@@ -150,7 +150,7 @@ To start the installer on all platforms:
 
     .. code-block:: bash
 
-        curl --location https://github.com/RudolfCardinal/crate/releases/latest/download/installer.sh --fail --output crate_docker_installer.sh && chmod u+x crate_docker_installer.sh && ./crate_docker_installer.sh
+        curl --location https://github.com/ucam-department-of-psychiatry/crate/releases/latest/download/installer.sh --fail --output crate_docker_installer.sh && chmod u+x crate_docker_installer.sh && ./crate_docker_installer.sh
 
 
 .. _docker_environment_variables:

--- a/docs/source/installation/installation.rst
+++ b/docs/source/installation/installation.rst
@@ -29,7 +29,7 @@ Installing CRATE
 URLs for CRATE source code
 --------------------------
 
-- https://github.com/RudolfCardinal/crate (for source)
+- https://github.com/ucam-department-of-psychiatry/crate (for source)
 - https://pypi.io/project/crate-anon/ (for ``pip install crate-anon``)
 
 

--- a/docs/source/introduction/package_elements.rst
+++ b/docs/source/introduction/package_elements.rst
@@ -35,7 +35,7 @@ research database. CRATE separates these stages.
 Terminology
 -----------
 
-I will refer to ‘anonymisation’ in this document, but sometimes as a shorthand
+We will refer to ‘anonymisation’ in this document, but sometimes as a shorthand
 for ‘pseudonymisation’, in which IDs are removed and replaced by a generated
 pseudonym.
 
@@ -143,6 +143,17 @@ first time.
 
 This tool uses a configuration file that you create and edit. Use ``crate_nlp
 --democonfig`` to generate a demonstration file.
+
+
+Linkage
+-------
+
+You might have more than one database and want to link them, so information
+about the same person in two databases can be analysed together. CRATE provides
+tools to do this whether two databases share a person-unique identifier (like a
+UK NHS number) or without. Linkage without a shared person-unique identifier is
+performed via a Bayesian personal identity matching process. This can be done
+in an entirely de-identified manner. See :ref:`linkage <linkage>`.
 
 
 Web front end

--- a/docs/source/linkage/fuzzy_id_match.rst
+++ b/docs/source/linkage/fuzzy_id_match.rst
@@ -30,7 +30,6 @@ address information. This is a probability-based ("fuzzy") matching technique.
 It can operate using either identifiable information or in de-identified
 fashion.
 
-**In development.**
 **More detail will follow when the validation paper is published.**
 
 .. todo:: fuzzy_id_match: expand on method

--- a/docs/source/linkage/index.rst
+++ b/docs/source/linkage/index.rst
@@ -19,6 +19,8 @@
     along with CRATE. If not, see <https://www.gnu.org/licenses/>.
 
 
+.. _linkage:
+
 Linkage tools
 =============
 

--- a/docs/source/linkage/overview_linkage.rst
+++ b/docs/source/linkage/overview_linkage.rst
@@ -19,6 +19,8 @@
     along with CRATE. If not, see <https://www.gnu.org/licenses/>.
 
 
+.. _linkage_overview:
+
 Linkage: overview
 -----------------
 

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -81,7 +81,7 @@ CRATE_INSTALLER_PYTHON=${CRATE_INSTALLER_PYTHON:-python3}
 # -----------------------------------------------------------------------------
 
 if [ ${PRODUCTION} -eq 1 ]; then
-    CRATE_GITHUB_REPOSITORY=https://github.com/RudolfCardinal/crate
+    CRATE_GITHUB_REPOSITORY=https://github.com/ucam-department-of-psychiatry/crate
     CRATE_TAR_FILE=crate.tar.gz
 
     # This doesn't work with GitHub generated assets for some reason so we rely


### PR DESCRIPTION
In my attempt to better understand the code, I've made what are hopefully improvements to the multiple comparison fuzzy linkage tests.

I've split the one test into separate tests and added checks for the returned matches. Without these checks all the tests would still pass with `, x._distance` removed from `sort_asc_best_to_worst()`

I'm hoping by predicting the order of the matches there aren't any flaky tests. I believe when a list is sorted in python and there is a tie between two entries, the original order should be retained.

Running a code coverage report (`pip install pytest-cov` and then `pytest --cov --cov-report html`) shows the `continue` when `ci is None` ([line 2390](https://github.com/RudolfCardinal/crate/blob/multiple-comparison-tests/crate_anon/linkage/identifiers.py#L2390)) is not currently tested. Would that be easy to do?