### PR TITLE
Filter name lists by common English words

### DIFF
--- a/docs/source/preprocessing/_crate_fetch_wordlists_help.txt
+++ b/docs/source/preprocessing/_crate_fetch_wordlists_help.txt
@@ -6,6 +6,15 @@ usage: crate_fetch_wordlists [-h] [--verbose]
                              [--english_words_output ENGLISH_WORDS_OUTPUT]
                              [--english_words_url ENGLISH_WORDS_URL]
                              [--valid_word_regex VALID_WORD_REGEX]
+                             [--gutenberg_word_freq]
+                             [--gutenberg_word_freq_output GUTENBERG_WORD_FREQ_OUTPUT]
+                             [--gutenberg_id_first GUTENBERG_ID_FIRST]
+                             [--gutenberg_id_last GUTENBERG_ID_LAST]
+                             [--filter_words_by_freq]
+                             [--wordfreqfilter_input WORDFREQFILTER_INPUT]
+                             [--wordfreqfilter_output WORDFREQFILTER_OUTPUT]
+                             [--wordfreqfilter_min_cum_freq WORDFREQFILTER_MIN_CUM_FREQ]
+                             [--wordfreqfilter_max_cum_freq WORDFREQFILTER_MAX_CUM_FREQ]
                              [--us_forenames]
                              [--us_forenames_freq_output US_FORENAMES_FREQ_OUTPUT]
                              [--us_forenames_sex_freq_output US_FORENAMES_SEX_FREQ_OUTPUT]
@@ -23,6 +32,7 @@ usage: crate_fetch_wordlists [-h] [--verbose]
                              [--eponyms] [--eponyms_output EPONYMS_OUTPUT]
                              [--eponyms_add_unaccented_versions [EPONYMS_ADD_UNACCENTED_VERSIONS]]
                              [--filter_input [FILTER_INPUT [FILTER_INPUT ...]]]
+                             [--filter_include [FILTER_INCLUDE [FILTER_INCLUDE ...]]]
                              [--filter_exclude [FILTER_EXCLUDE [FILTER_EXCLUDE ...]]]
                              [--filter_output [FILTER_OUTPUT]]
 
@@ -38,9 +48,9 @@ optional arguments:
                         your preferred frequency thresholds) (default: None)
 
 English words:
-  --english_words       Fetch English words (to remove from the nonspecific
-                        denylist, not to add to an allowlist; consider words
-                        like smith) (default: False)
+  --english_words       Fetch English words (e.g. to remove from the
+                        nonspecific denylist, not to add to an allowlist;
+                        consider words like smith) (default: False)
   --english_words_output ENGLISH_WORDS_OUTPUT
                         Output file for English words (default: None)
   --english_words_url ENGLISH_WORDS_URL
@@ -50,6 +60,36 @@ English words:
   --valid_word_regex VALID_WORD_REGEX
                         Regular expression to determine valid English words
                         (default: ^[a-z](?:[A-Za-z'-]*[a-z])*$)
+  --gutenberg_word_freq
+                        Fetch words from Project Gutenberg with frequencies
+                        (default: False)
+  --gutenberg_word_freq_output GUTENBERG_WORD_FREQ_OUTPUT
+                        Output file for English words with frequencies. CSV
+                        file with columns: word, word_freq, cum_freq.
+                        (default: None)
+  --gutenberg_id_first GUTENBERG_ID_FIRST
+                        For word counting: first Project Gutenberg book ID
+                        (default: 100)
+  --gutenberg_id_last GUTENBERG_ID_LAST
+                        For word counting: last Project Gutenberg book ID
+                        (default: 110)
+
+Filter English words by frequency:
+  --filter_words_by_freq
+                        Read a CSV file from --gutenberg_word_freq, filter it
+                        by cumulative word frequency, and write a plain list
+                        of words. (default: False)
+  --wordfreqfilter_input WORDFREQFILTER_INPUT
+                        Input filename. Usually the output of
+                        --gutenberg_word_freq_output. (default: None)
+  --wordfreqfilter_output WORDFREQFILTER_OUTPUT
+                        Output filename. Plain text file. (default: None)
+  --wordfreqfilter_min_cum_freq WORDFREQFILTER_MIN_CUM_FREQ
+                        Minimum cumulative frequency. (Set to >0 to exclude
+                        common words.) (default: 0.0)
+  --wordfreqfilter_max_cum_freq WORDFREQFILTER_MAX_CUM_FREQ
+                        Maximum cumulative frequency. (Set to <1 to exclude
+                        rare words.) (default: 1.0)
 
 US forenames:
   --us_forenames        Fetch US forenames (for denylist) (default: False)
@@ -130,16 +170,21 @@ Medical eponyms:
                         Sjögren) (default: True)
 
 Filter functions:
-  Extra functions to filter wordlists. Specify an input file (or files),
-  whose lines will be included; optional exclusion file(s), whose lines will
-  be excluded (in case-insensitive fashion); and an output file. You can use
-  '-' for the output file to mean 'stdout', and for one input file to mean
+  Extra functions to filter wordlists.Specify an input file, optional
+  exclusion and/or inclusion file(s), and an output file. You can use '-'
+  for the output file to mean 'stdout', and for one input file to mean
   'stdin'. No filenames (other than '-' for input and output) may overlap.
   The --min_line_length option also applies. Duplicates are not removed.
 
   --filter_input [FILTER_INPUT [FILTER_INPUT ...]]
-                        Input file(s). See above. (default: None)
+                        Input file(s). Words will be drawn from these files.
+                        (default: None)
+  --filter_include [FILTER_INCLUDE [FILTER_INCLUDE ...]]
+                        Inclusion file(s). If any inclusion files are
+                        specified, words from the input must be present in at
+                        least one inclusion file to pass. (default: None)
   --filter_exclude [FILTER_EXCLUDE [FILTER_EXCLUDE ...]]
-                        Exclusion file(s). See above. (default: None)
+                        Exclusion file(s). Any words present in the exclusion
+                        files do not pass. (default: None)
   --filter_output [FILTER_OUTPUT]
-                        Exclusion file(s). See above. (default: None)
+                        Output file. Words are written here. (default: None)

--- a/docs/source/preprocessing/crate_fetch_wordlists_specimen_usage.sh
+++ b/docs/source/preprocessing/crate_fetch_wordlists_specimen_usage.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Generating name files under Linux, for nonspecific name removal.
 
+# -----------------------------------------------------------------------------
 # 1. Fetch our source data.
+# -----------------------------------------------------------------------------
 # Downloading these and then using a file:// URL is unnecessary, but it makes
 # the processing steps faster if we need to retry with new settings.
 wget https://www.gutenberg.org/files/3201/files/CROSSWD.TXT -O dictionary.txt
@@ -9,12 +11,16 @@ wget https://www.ssa.gov/OACT/babynames/names.zip -O forenames.zip
 wget http://www2.census.gov/topics/genealogy/1990surnames/dist.all.last -O surnames_1990.txt
 wget https://www2.census.gov/topics/genealogy/2010surnames/names.zip -O surnames_2010.zip
 
+# -----------------------------------------------------------------------------
 # 2. Create our wordlists.
-#    (We'll illustrate frequencies for some names that are also words.)
+# -----------------------------------------------------------------------------
+# Fetch forenames, surnames, medical eponyms, and words valid for Scrabble.
+# Via --debug_names, we'll illustrate frequencies for some names that are also
+# words.
 crate_fetch_wordlists \
     --english_words \
         --english_words_url "file://${PWD}/dictionary.txt" \
-        --english_words_output english_words.txt \
+        --english_words_output english_crossword_words.txt \
     --us_forenames \
         --us_forenames_url "file://${PWD}/forenames.zip" \
         --us_forenames_max_cumfreq_pct 100 \
@@ -31,14 +37,44 @@ crate_fetch_wordlists \
         knuckle libel limp lovely man memory mood music no power powers sad \
         stress true veronica yes you young zone
 
+# Count frequencies for a few books (preserving case, filtering for words of
+# length 2+ and meeting a valid pattern which includes starting with a
+# lower-case letter), across 1,134,142 words:
+crate_fetch_wordlists \
+      --gutenberg_word_freq \
+      --gutenberg_id_first 100 \
+      --gutenberg_id_last 110 \
+      --gutenberg_word_freq_output english_word_freq_gutenberg.csv
+# 100 is Shakespeare: https://www.gutenberg.org/ebooks/100
+
+# Filter to common words, that account together for the top 99% of usage.
+crate_fetch_wordlists \
+    --filter_words_by_freq \
+    --wordfreqfilter_input english_word_freq_gutenberg.csv \
+    --wordfreqfilter_min_cum_freq 0.0 \
+    --wordfreqfilter_max_cum_freq 0.99 \
+    --wordfreqfilter_output english_gutenberg_common_words.txt
+# In this corpus, "john" comes in at about 0.9923.
+
+# Create a list of common English words -- the overlap between "common words in
+# Project Gutenberg books" and "valid Scrabble words".
+crate_fetch_wordlists \
+    --filter_input english_gutenberg_common_words.txt \
+    --filter_include english_crossword_words.txt \
+    --filter_output common_english_words.txt
+
+# -----------------------------------------------------------------------------
 # 3. Generate an amalgamated and filtered wordlist.
+# -----------------------------------------------------------------------------
 crate_fetch_wordlists \
     --filter_input us_forenames.txt us_surnames.txt \
-    --filter_exclude medical_eponyms.txt \
+    --filter_exclude medical_eponyms.txt common_english_words.txt \
     --filter_output filtered_names.txt
+#                   ^^^^^^^^^^^^^^^^^^
+# This may be useful for the CRATE anonymiser option --denylist_filenames.
 
-# If we don't "--filter_exclude english_words.txt", then this is the overlap:
+# As a check, these are then names that are *rare* English words:
 comm -12 \
     <(sort filtered_names.txt | tr "[:upper:]" "[:lower:]") \
-    <(sort english_words.txt | tr "[:upper:]" "[:lower:]") \
-    > names_that_are_english_words.txt
+    <(sort english_crossword_words.txt | tr "[:upper:]" "[:lower:]") \
+    > remaining_names_that_are_english_crossword_words.txt

--- a/docs/source/preprocessing/index.rst
+++ b/docs/source/preprocessing/index.rst
@@ -124,16 +124,6 @@ denial, and words to exclude from such lists (such as English words or medical
 eponyms). It also provides an exclusion filter system, to find lines in some
 files that are absent from others.
 
-Options:
-
-..  literalinclude:: _crate_fetch_wordlists_help.txt
-    :language: none
-
-Specimen usage:
-
-..  literalinclude:: crate_fetch_wordlists_specimen_usage.sh
-    :language: bash
-
 The purpose of creating large name lists is usually to remove more names.
 However, it's likely that you want to remove medical eponyms, like Parkinson
 (for Parkinson's disease). CRATE has a hand-curated list of these. (If a
@@ -145,14 +135,30 @@ impossible.)
 
 The overlap between names and English words is really tricky.
 
-- If you use all names from this set and exclude English words (e.g.
-  ``--filter-exclude english_words.txt medical_eponyms.txt``), you will remove
-  from the namelist (and thus NOT remove from text being nonspecifically
-  scrubbed) names such as John (john is a noun) and Veronica (veronica
-  is also a noun).
+- If you use all names from this set and exclude all valid English words (e.g.
+  from a "valid answers in Scrabble or crosswords" list), you will remove from
+  the namelist -- and thus NOT remove from text being nonspecifically scrubbed
+  -- names such as John (john is a noun) and Veronica (veronica is also a
+  noun).
 
-- If you keep all name in the exclusion namelist, though, you will scrub words
+- If you keep all names in the exclusion namelist, though, you will scrub words
   like excellent, fought, friend, games, he, hope, husband, joyful, kitten,
   knuckle, libel, limp, lovely, man, memory, mood, music, no, power, powers,
   sad, stress, true, yes, you, young, zone (to list but a few); these are all
   names.
+
+- A compromise may be to start with all names, remove medical eponyms, and
+  remove *common* English words. CRATE provides tools to count words in a
+  subset of the Project Gutenberg corpus. For example, removing English words
+  that account for the top 99% of this corpus (and are also valid Scrabble
+  clues) does this. The process is shown in the specimen usage below.
+
+Options:
+
+..  literalinclude:: _crate_fetch_wordlists_help.txt
+    :language: none
+
+Specimen usage:
+
+..  literalinclude:: crate_fetch_wordlists_specimen_usage.sh
+    :language: bash

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ INSTALL_REQUIRES = [
     "flower==1.1.0",  # debug Celery; web server; only runs explicitly
     "fuzzy==1.2.2",  # phonetic matching
     "gunicorn==20.0.4",  # UNIX only, though will install under Windows
+    "gutenbergpy==0.3.4",  # Project Gutenberg API
     "jsonlines==3.0.0",  # JSON Lines format
     "kombu==5.2.3",  # AMQP library for Celery; requires VC++ under Windows
     "mako==1.1.3",  # templates with Python in


### PR DESCRIPTION
Fetch all words from a subset of Project Gutenberg books.
Filter, e.g. must start with a lower-case letter; >=2 characters. This should remove some usages as names (although also starts of sentences, of course).
Then (in the specimen usage), trim to the top 99% and overlap with valid Scrabble/crossword clues; this gives a list of common English words.
Take all US forenames/surnames, subtract eponyms, subtract the new list of common English words, and use the result as our name exclusion file.

This gets rid of e.g. John, Veronica, but doesn't exclude e.g. excellent, moody.