### PR TITLE
Fuzzy linkage updates for paper revisions.

### DIFF
--- a/crate_anon/linkage/fuzzy_id_match.py
+++ b/crate_anon/linkage/fuzzy_id_match.py
@@ -145,7 +145,7 @@ block, and then compare the sequence of mini-hashes for similarity.
     triggered piecewise hashing", *Digital Investigation* 3S: S91-S97,
     https://doi.org/10.1016/j.diin.2006.06.015.
 
-... cited in the paper via Kornblum (2006) and Lee & Atkinson (2017), which
+... cited in the paper via Kornblum (2006) and Lee & Atkison (2017), which
 covers SSDEEP, TLSH, sdhash, and others.
 
 

--- a/crate_anon/linkage/fuzzy_id_match.py
+++ b/crate_anon/linkage/fuzzy_id_match.py
@@ -199,6 +199,7 @@ class ComparisonOutputColnames:
     SECOND_BEST_LOG_ODDS = "second_best_log_odds"
 
     BEST_CANDIDATE_LOCAL_ID = "best_candidate_local_id"
+    SECOND_BEST_CANDIDATE_LOCAL_ID = "second_best_candidate_local_id"
 
     COMPARISON_OUTPUT_COLNAMES = [
         PROBAND_LOCAL_ID,
@@ -208,7 +209,10 @@ class ComparisonOutputColnames:
         SAMPLE_MATCH_LOCAL_ID,
         SECOND_BEST_LOG_ODDS,
     ]
-    COMPARISON_EXTRA_COLNAMES = [BEST_CANDIDATE_LOCAL_ID]
+    COMPARISON_EXTRA_COLNAMES = [
+        BEST_CANDIDATE_LOCAL_ID,
+        SECOND_BEST_CANDIDATE_LOCAL_ID,
+    ]
 
 
 _ = """
@@ -375,6 +379,11 @@ def compare_probands_to_sample(
         if extra_validation_output:
             rowdata[c.BEST_CANDIDATE_LOCAL_ID] = (
                 r.best_candidate.local_id if r.best_candidate else None
+            )
+            rowdata[c.SECOND_BEST_CANDIDATE_LOCAL_ID] = (
+                r.second_best_candidate.local_id
+                if r.second_best_candidate
+                else None
             )
         writer.writerow(rowdata)
 
@@ -804,6 +813,15 @@ def get_demo_people(cfg: MatchConfig = None) -> List[Person]:
             gender=GENDER_FEMALE,
             postcodes=[p("CB2 0QQ")],
         ),
+        Person(
+            cfg=cfg,
+            local_id="r13",
+            other_info=mkother("13"),
+            forenames=["Sherlock"],
+            surnames=["Holmes"],
+            # no DOB
+            gender=GENDER_MALE,
+        ),
     ]
 
 
@@ -867,6 +885,9 @@ added:
         Local ID of the closest-matching person (candidate) in the sample, EVEN
         IF THEY DID NOT WIN. (This will be the same as the winner if there was
         a match.) String; blank for no match.
+    {ComparisonOutputColnames.SECOND_BEST_CANDIDATE_LOCAL_ID}:
+        Local ID of the second-best candidate in the sample, if any. String;
+        blank for no match.
 
 Proband order is retained in the output (even using parallel processing).
 """
@@ -913,6 +934,7 @@ def add_subparsers(
     parser.add_argument(
         "--version", action="version", version=f"CRATE {CRATE_VERSION}"
     )
+    # noinspection PyTypeChecker
     parser.add_argument(
         "--allhelp",
         action=ShowAllSubparserHelpAction,
@@ -1319,7 +1341,9 @@ def add_matching_rules(parser: argparse.ArgumentParser) -> None:
     control_group.add_argument(
         f"--{Switches.EXTRA_VALIDATION_OUTPUT}",
         action="store_true",
-        help="Add extra output for validation purposes.",
+        help="Add extra output for validation purposes (the local IDs of the "
+        "best and second-best candidates, if any, even if there was no "
+        "match).",
     )
     control_group.add_argument(
         f"--{Switches.CHECK_COMPARISON_ORDER}",

--- a/crate_anon/linkage/people.py
+++ b/crate_anon/linkage/people.py
@@ -164,6 +164,15 @@ class People:
             self.dob_yd_to_people[dob.dob_yd].append(person)
             self.dob_ym_to_people[dob.dob_ym].append(person)
             self.dob_ymd_to_people[dob.dob_str].append(person)
+        else:
+            # DOB absent.
+            # We do need a way to retrieve people with no DOB.
+            # We use a blank string key for this:
+            self.dob_ymd_to_people[""].append(person)
+            # It's also true that dob.dob_str will be "", so this is just for
+            # clarity.
+            # We do not need to add to the partial DOB maps. See
+            # gen_shortlist().
 
         # Add the person.
         self.people.append(person)
@@ -229,9 +238,14 @@ class People:
         # A high-speed function.
         cfg = self.cfg
         dob = proband.dob
-        if not dob:
-            return
-        if cfg.complete_dob_mismatch_allowed:
+
+        # 2023-02-28 update for referees:
+        # - Allow comparison where the DOB is missing.
+        # - Of necessity, probands with no DOBs must be compared to all
+        #   candidates.
+        # - Likewise, if we permit a complete DOB mismatch (where DOBs are
+        #   present), we must compare to all candidates.
+        if cfg.complete_dob_mismatch_allowed or not dob:
             # No shortlisting; everyone's a candidate. Slow.
             for person in self.people:
                 # self.people is a list, so order is consistent and matches
@@ -256,6 +270,11 @@ class People:
                 shortlist.update(self.dob_md_to_people[dob.dob_md])
                 shortlist.update(self.dob_yd_to_people[dob.dob_yd])
                 shortlist.update(self.dob_ym_to_people[dob.dob_ym])
+
+            # But also, we must include any candidates who have no DOB.
+            # (We already know that our proband has a DOB, or we wouldn't be
+            # in this part of the if statement.)
+            shortlist.update(self.dob_ymd_to_people[""])
 
             for person in shortlist:
                 yield person

--- a/crate_anon/linkage/person.py
+++ b/crate_anon/linkage/person.py
@@ -168,9 +168,9 @@ class Person:
                 TemporalIDHolder objects.
             dob:
                 The date of birth, in ISO-8061 "YYYY-MM-DD" string format,
-                or as a DateOfBirth object.
+                or as a DateOfBirth object, or None, or ''.
             gender:
-                The gender: 'M', 'F', 'X', or '', or a Gender object.
+                The gender: 'M', 'F', 'X', or '', or None, or a Gender object.
             postcodes:
                 Any UK postcodes for this person, with optional associated
                 dates.
@@ -272,8 +272,9 @@ class Person:
             chk_plaintext(s)
             self.surnames.append(s)
 
-        # dob (NB mandatory for real work but we still want to be able to
-        # create Person objects without a DOB inc. for testing)
+        # dob (NB highly desirable for real work, but not mandatory, and we
+        # also want to be able to create Person objects without a DOB for
+        # testing)
         dob = "" if dob is None else dob
         if isinstance(dob, DateOfBirth):
             self.dob = dob
@@ -708,15 +709,13 @@ class Person:
     # Validation
     # -------------------------------------------------------------------------
 
-    def ensure_valid_as_proband(
-        self, debug_allow_no_dob: bool = False
-    ) -> None:
+    def ensure_valid_as_proband(self) -> None:
         """
         Ensures this person has sufficient information to act as a proband, or
         raises :exc:`ValueError`.
+
+        We previously required a DOB unless debugging, but no longer.
         """
-        if not self.has_dob() and not debug_allow_no_dob:
-            raise ValueError("Proband: missing DOB")
         for f in self.forenames:
             f.ensure_has_freq_info_if_id_present()
         for s in self.surnames:
@@ -726,15 +725,14 @@ class Person:
         for p in self.postcodes:
             p.ensure_has_freq_info_if_id_present()
 
-    def ensure_valid_as_candidate(
-        self, debug_allow_no_dob: bool = False
-    ) -> None:
+    def ensure_valid_as_candidate(self) -> None:
         """
         Ensures this person has sufficient information to act as a candidate,
         or raises :exc:`AssertionError`.
+
+        We previously required a DOB unless debugging, but no longer.
         """
-        if not self.has_dob() and not debug_allow_no_dob:
-            raise ValueError("Candidate: missing DOB")
+        pass
 
     # -------------------------------------------------------------------------
     # Debugging functions to check this object

--- a/crate_anon/linkage/tests/fuzzy_id_match_tests.py
+++ b/crate_anon/linkage/tests/fuzzy_id_match_tests.py
@@ -324,7 +324,7 @@ class TestCondition:
 
         for id_person in (self.person_a, self.person_b):
             assert id_person.is_plaintext()
-            id_person.ensure_valid_as_proband(debug_allow_no_dob=True)
+            id_person.ensure_valid_as_proband()
             for identifier in id_person.debug_gen_identifiers():
                 assert identifier.is_plaintext
 
@@ -333,7 +333,7 @@ class TestCondition:
         self.hashed_b = self.person_b.hashed()
         for h_person in (self.hashed_a, self.hashed_b):
             assert h_person.is_hashed()
-            h_person.ensure_valid_as_proband(debug_allow_no_dob=True)
+            h_person.ensure_valid_as_proband()
             for identifier in h_person.debug_gen_identifiers():
                 assert not identifier.is_plaintext
         self.debug = debug

--- a/crate_anon/linkage/validation/test_01_make_inputs.py
+++ b/crate_anon/linkage/validation/test_01_make_inputs.py
@@ -120,6 +120,8 @@ def main() -> None:
         ),
         10000,
     )
+
+    # Don't alter this: it provides the five-example Figure 3.
     write_people(
         filename=os.path.join(
             FuzzyDefaults.DEFAULT_CACHE_DIR, "crate_fuzzy_demo_fig3_sample.csv"

--- a/crate_anon/linkage/validation/test_02_selftest.sh
+++ b/crate_anon/linkage/validation/test_02_selftest.sh
@@ -62,7 +62,8 @@ rm -f "${SAMPLE_CACHE}"
     --probands "${SAMPLE}" \
     --sample "${SAMPLE}" \
     --sample_cache "${SAMPLE_CACHE}" \
-    --output "${COMPARISON_P2P}"
+    --output "${COMPARISON_P2P}" \
+    --extra_validation_output
 
 # (b) From the cache at the previous step
 # This should produce matches for most (comparing a sample to itself):
@@ -70,7 +71,8 @@ rm -f "${SAMPLE_CACHE}"
     --probands "${SAMPLE}" \
     --sample "${SAMPLE}" \
     --sample_cache "${SAMPLE_CACHE}" \
-    --output "${COMPARISON_P2P}"
+    --output "${COMPARISON_P2P}" \
+    --extra_validation_output
 
 # For larger comparisons, see the speedtest script.
 
@@ -84,6 +86,7 @@ rm -f "${SAMPLE_CACHE}"
     --probands "${SAMPLE_HASHED}" \
     --sample "${SAMPLE_HASHED}" \
     --output "${COMPARISON_H2H}" \
+    --extra_validation_output \
     --n_workers 1
 cmp "${COMPARISON_H2H}" "${COMPARISON_P2P}" || { echo "H2H doesn't match P2P"; exit 1; }
 
@@ -92,6 +95,7 @@ cmp "${COMPARISON_H2H}" "${COMPARISON_P2P}" || { echo "H2H doesn't match P2P"; e
     --probands "${SAMPLE_HASHED}" \
     --sample "${SAMPLE}" \
     --output "${COMPARISON_H2P}" \
+    --extra_validation_output \
     --n_workers 1 \
     --rounding_sf None
 cmp "${COMPARISON_H2P}" "${COMPARISON_P2P}" || { echo "H2P doesn't match P2P"; exit 1; }

--- a/crate_anon/linkage/validation/test_04_verbose_comparison.py
+++ b/crate_anon/linkage/validation/test_04_verbose_comparison.py
@@ -36,14 +36,17 @@ from cardinal_pythonlib.logs import main_only_quicksetup_rootlogger
 from crate_anon.linkage.fuzzy_id_match import get_demo_people
 from crate_anon.linkage.matchconfig import MatchConfig
 
+log = logging.getLogger(__name__)
+
 
 def main(
-    wholly_different: bool = False,
-    asymmetry_forename_count: bool = False,
-    asymmetry_surname_frequency: bool = False,
-    use_dummy_frequencies: bool = False,
-    forename_order_1: bool = False,
+    wholly_different: bool = True,
+    asymmetry_forename_count: bool = True,
+    asymmetry_surname_frequency: bool = True,
+    use_dummy_frequencies: bool = True,
+    forename_order_1: bool = True,
     forename_order_2: bool = True,
+    no_dob: bool = True,
     verbose: bool = False,
 ) -> None:
     """
@@ -62,26 +65,36 @@ def main(
     a_smith = pp[10]  # Alice SMITH, one postcode
     a_abadilla = pp[11]  # Alice ABADILLA, one postcode
     za_smith = pp[12]  # Zara Alice SMITH, one postcode
+    s_holmes = pp[13]  # Sherlock HOLMES, no DOB
 
     if wholly_different:
+        log.warning("Wholly different")
         az_smith.debug_compare(candidate=dww_cartwright, verbose=verbose)
         dww_cartwright.debug_compare(candidate=az_smith, verbose=verbose)
 
     if asymmetry_forename_count:
+        log.warning("Asymmetric forename count")
         az_smith.debug_compare(candidate=a_smith, verbose=verbose)
         a_smith.debug_compare(candidate=az_smith, verbose=verbose)
 
     if asymmetry_surname_frequency:
+        log.warning("Asymmetric surname frequency")
         a_smith.debug_compare(candidate=a_abadilla, verbose=verbose)
         a_abadilla.debug_compare(candidate=a_smith, verbose=verbose)
 
     if forename_order_1:
+        log.warning("Forename order 1")
         az_smith.debug_compare(candidate=az_smith, verbose=verbose)
         az_smith.debug_compare(candidate=za_smith, verbose=verbose)
 
     if forename_order_2:
+        log.warning("Forename order 2")
         a_smith.debug_compare(candidate=az_smith, verbose=verbose)
         a_smith.debug_compare(candidate=za_smith, verbose=verbose)
+
+    if no_dob:
+        log.warning("No DOB")
+        s_holmes.debug_compare(candidate=s_holmes, verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/docs/source/linkage/_crate_fuzzy_id_match_help.txt
+++ b/docs/source/linkage/_crate_fuzzy_id_match_help.txt
@@ -330,6 +330,9 @@ added:
         Local ID of the closest-matching person (candidate) in the sample, EVEN
         IF THEY DID NOT WIN. (This will be the same as the winner if there was
         a match.) String; blank for no match.
+    second_best_candidate_local_id:
+        Local ID of the second-best candidate in the sample, if any. String;
+        blank for no match.
 
 Proband order is retained in the output (even using parallel processing).
 
@@ -399,8 +402,9 @@ MATCHING RULES:
 
 CONTROL OPTIONS:
   --extra_validation_output
-                        Add extra output for validation purposes. (default:
-                        False)
+                        Add extra output for validation purposes (the local
+                        IDs of the best and second-best candidates, if any,
+                        even if there was no match). (default: False)
   --check_comparison_order
                         Check every comparison for log-likelihood ratio
                         sequence 'no match ≤ partial(s) ≤ full' and warn if
@@ -671,6 +675,9 @@ added:
         Local ID of the closest-matching person (candidate) in the sample, EVEN
         IF THEY DID NOT WIN. (This will be the same as the winner if there was
         a match.) String; blank for no match.
+    second_best_candidate_local_id:
+        Local ID of the second-best candidate in the sample, if any. String;
+        blank for no match.
 
 Proband order is retained in the output (even using parallel processing).
 
@@ -712,8 +719,9 @@ MATCHING RULES:
 
 CONTROL OPTIONS:
   --extra_validation_output
-                        Add extra output for validation purposes. (default:
-                        False)
+                        Add extra output for validation purposes (the local
+                        IDs of the best and second-best candidates, if any,
+                        even if there was no match). (default: False)
   --check_comparison_order
                         Check every comparison for log-likelihood ratio
                         sequence 'no match ≤ partial(s) ≤ full' and warn if
@@ -990,6 +998,9 @@ added:
         Local ID of the closest-matching person (candidate) in the sample, EVEN
         IF THEY DID NOT WIN. (This will be the same as the winner if there was
         a match.) String; blank for no match.
+    second_best_candidate_local_id:
+        Local ID of the second-best candidate in the sample, if any. String;
+        blank for no match.
 
 Proband order is retained in the output (even using parallel processing).
 
@@ -1067,8 +1078,9 @@ MATCHING RULES:
 
 CONTROL OPTIONS:
   --extra_validation_output
-                        Add extra output for validation purposes. (default:
-                        False)
+                        Add extra output for validation purposes (the local
+                        IDs of the best and second-best candidates, if any,
+                        even if there was no match). (default: False)
   --check_comparison_order
                         Check every comparison for log-likelihood ratio
                         sequence 'no match ≤ partial(s) ≤ full' and warn if

--- a/docs/source/nlp/nlprp.rst
+++ b/docs/source/nlp/nlprp.rst
@@ -61,10 +61,10 @@ Authors
 In alphabetical order:
 
 - Rudolf N. Cardinal (RNC), University of Cambridge, 2017-.
-- Joe Kearney (JK), University of Cambridge, 2018.
+- Joe Kearney (JK), University of Cambridge, 2018-19.
 - Angus Roberts (AR), King's College London, 2018-.
 - Ian Roberts (IR), University of Sheffield, 2018-.
-- Francesca Spivack (FS), University of Cambridge, 2018-.
+- Francesca Spivack (FS), University of Cambridge, 2018-20.
 
 
 Rationale

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ INSTALL_REQUIRES = [
     "numba==0.55.2",  # just-in-time compilation of functions
     "numpy==1.22.4",  # numerical work
     "openpyxl==3.0.7",  # read Excel
+    "ordered-set==4.1.0",  # ordered sets; search for ordered_set
     "pendulum==2.1.2",  # dates/times
     "Pillow==9.3.0",  # image processing; import as PIL (Python Imaging Library)  # noqa: E501
     "pdfkit==0.6.1",  # interface to wkhtmltopdf


### PR DESCRIPTION
Updates to Bayesian fuzzy linkage system.

Main things are:
* Support comparisons with missing DOBs in full. (Probands with no DOB are compared to all candidates. Candidates with no DOB are compared to all probands.)
* ``OrderedSet`` used in the creation of shortlists, rather than ``set``, to guarantee order relative to the input (for the first-of-a-tie-wins log odds comparison system).

Also:
* The ``--extra_validation_output`` option now includes the ID of the second best candidate (not just the second-best log odds), so it's easier to see the effects of changes.