### PR TITLE
Fix full text index error on SQL Server

### DIFF
--- a/crate_anon/anonymise/tests/anonymise_tests.py
+++ b/crate_anon/anonymise/tests/anonymise_tests.py
@@ -26,23 +26,31 @@ crate_anon/anonymise/tests/anonymise_tests.py
 """
 
 import logging
+from typing import Any, Dict, Generator, List, Tuple
 from unittest import mock
 
+from cardinal_pythonlib.sqlalchemy.schema import mssql_table_has_ft_index
 import factory
+import pytest
 from sqlalchemy import (
     Boolean,
     Column,
+    create_engine,
+    inspect,
     Integer,
     String,
 )
 
-from crate_anon.testing import Base
-from crate_anon.testing.classes import DatabaseTestCase
-from crate_anon.testing.factories import BaseFactory
 from crate_anon.anonymise.anonymise import (
+    create_indexes,
     gen_opt_out_pids_from_database,
     validate_optouts,
 )
+from crate_anon.anonymise.constants import IndexType
+from crate_anon.anonymise.ddr import DataDictionaryRow
+from crate_anon.testing import Base
+from crate_anon.testing.classes import DatabaseTestCase
+from crate_anon.testing.factories import BaseFactory
 
 
 class TestBoolOptOut(Base):
@@ -75,6 +83,14 @@ class TestStringOptOutFactory(BaseFactory):
 
     pid = factory.Sequence(lambda n: n + 1)
     mpid = factory.Sequence(lambda n: n + 1)
+
+
+class TestAnonPatient(Base):
+    __tablename__ = "anon_patient"
+
+    pid = Column(Integer, primary_key=True, comment="Patient ID")
+    forename = Column(String(50), comment="Forename")
+    surname = Column(String(50), comment="Surname")
 
 
 class GenOptOutPidsFromDatabaseTests(DatabaseTestCase):
@@ -248,3 +264,129 @@ class ValidateOptoutsTests(DatabaseTestCase):
                 str(cm.exception),
                 "No valid opt-out values for column 'opt_out'",
             )
+
+
+class CreateIndexesTests(DatabaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._engine_outside_transaction = None
+
+    def test_full_text_index_created_with_mysql(self) -> None:
+        if self.engine.dialect.name != "mysql":
+            pytest.skip("Skipping mysql-only test")
+
+        if self._get_mysql_anon_patient_table_full_text_indexes():
+            self._drop_mysql_full_text_indexes()
+
+        indexes = self._get_mysql_anon_patient_table_full_text_indexes()
+        self.assertEqual(len(indexes), 0)
+
+        self._make_full_text_index()
+        indexes = self._get_mysql_anon_patient_table_full_text_indexes()
+
+        self.assertEqual(len(indexes), 2)
+        self.assertEqual(indexes["forename"]["type"], "FULLTEXT")
+        self.assertEqual(indexes["surname"]["type"], "FULLTEXT")
+
+    def _drop_mysql_full_text_indexes(self) -> None:
+        sql = "DROP INDEX _idxft_forename ON anon_patient"
+        self.engine.execute(sql)
+
+        sql = "DROP INDEX _idxft_surname ON anon_patient"
+        self.engine.execute(sql)
+
+    def _get_mysql_anon_patient_table_full_text_indexes(
+        self,
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        return {
+            i["column_names"][0]: i
+            for i in inspect(self.engine).get_indexes("anon_patient")
+        }
+
+    def test_full_text_index_created_with_mssql(self) -> None:
+        if self.engine.dialect.name != "mssql":
+            pytest.skip("Skipping mssql-only test")
+
+        self._drop_mssql_full_text_indexes()
+
+        self.assertFalse(self._mssql_anon_patient_table_has_full_text_index())
+        self._make_full_text_index()
+
+        self.assertTrue(self._mssql_anon_patient_table_has_full_text_index())
+
+    def _mssql_anon_patient_table_has_full_text_index(self) -> None:
+        return mssql_table_has_ft_index(
+            self.engine_outside_transaction, "anon_patient", "dbo"
+        )
+
+    def _drop_mssql_full_text_indexes(self) -> None:
+        # SQL Server only. Need to be outside a transaction to drop indexes
+        sql = """
+IF EXISTS (
+    SELECT fti.object_id FROM sys.fulltext_indexes fti
+    WHERE fti.object_id = OBJECT_ID(N'[dbo].[anon_patient]')
+)
+
+DROP FULLTEXT INDEX ON [dbo].[anon_patient]
+"""
+        self.engine_outside_transaction.execute(sql)
+
+    @property
+    def engine_outside_transaction(self) -> None:
+        if self._engine_outside_transaction is None:
+            self._engine_outside_transaction = create_engine(
+                self.engine.url,
+                encoding="utf-8",
+                connect_args={"autocommit": True},  # for pyodbc
+            )
+
+        return self._engine_outside_transaction
+
+    def test_full_text_index_with_sqlite_not_possible(self) -> None:
+        if self.engine.dialect.name != "sqlite":
+            pytest.skip("Skipping sqlite-only test")
+
+        with self.assertLogs(level=logging.ERROR) as logging_cm:
+            self._make_full_text_index()
+
+        logger_name = "cardinal_pythonlib.sqlalchemy.schema"
+        expected_message = (
+            "Don't know how to make full text index on dialect sqlite"
+        )
+        self.assertIn(
+            f"ERROR:{logger_name}:{expected_message}", logging_cm.output
+        )
+
+    def _make_full_text_index(self) -> None:
+        mock_config = None
+
+        def index_row_sets(
+            tasknum: int = 0, ntasks: int = 1
+        ) -> Generator[Tuple[str, List[DataDictionaryRow]], None, None]:
+            forename_row = DataDictionaryRow(mock_config)
+            forename_row.dest_field = "forename"
+            forename_row.index = IndexType.FULLTEXT
+            surname_row = DataDictionaryRow(mock_config)
+            surname_row.dest_field = "surname"
+            surname_row.index = IndexType.FULLTEXT
+
+            for set in [
+                ("TestAnonPatient", [forename_row, surname_row]),
+            ]:
+                yield set
+
+        mock_dd = mock.Mock(
+            get_dest_sqla_table=mock.Mock(
+                return_value=TestAnonPatient.__table__
+            )
+        )
+        with mock.patch.multiple(
+            "crate_anon.anonymise.anonymise",
+            gen_index_row_sets_by_table=index_row_sets,
+        ):
+            with mock.patch.multiple(
+                "crate_anon.anonymise.anonymise.config",
+                dd=mock_dd,
+                _destination_database_url=self.engine.url,
+            ) as mock_config:
+                create_indexes()

--- a/crate_anon/anonymise/tests/anonymise_tests.py
+++ b/crate_anon/anonymise/tests/anonymise_tests.py
@@ -342,21 +342,6 @@ DROP FULLTEXT INDEX ON [dbo].[anon_patient]
 
         return self._engine_outside_transaction
 
-    def test_full_text_index_with_sqlite_not_possible(self) -> None:
-        if self.engine.dialect.name != "sqlite":
-            pytest.skip("Skipping sqlite-only test")
-
-        with self.assertLogs(level=logging.ERROR) as logging_cm:
-            self._make_full_text_index()
-
-        logger_name = "cardinal_pythonlib.sqlalchemy.schema"
-        expected_message = (
-            "Don't know how to make full text index on dialect sqlite"
-        )
-        self.assertIn(
-            f"ERROR:{logger_name}:{expected_message}", logging_cm.output
-        )
-
     def _make_full_text_index(self) -> None:
         mock_config = None
 

--- a/crate_anon/anonymise/tests/researcher_report_tests.py
+++ b/crate_anon/anonymise/tests/researcher_report_tests.py
@@ -41,7 +41,7 @@ from crate_anon.anonymise.researcher_report import (
     ResearcherReportConfig,
     TEMPLATE_DIR,
 )
-from crate_anon.testing import metadata
+from crate_anon.testing import Base
 from crate_anon.testing.classes import DemoDatabaseTestCase
 from crate_anon.testing.factories import DemoPatientFactory
 
@@ -95,7 +95,7 @@ class ResearcherReportTests(DemoDatabaseTestCase):
         with NamedTemporaryFile(delete=False, mode="w") as f:
             mock_db = mock.Mock(
                 table_names=["patient", "note"],
-                metadata=metadata,
+                metadata=Base.metadata,
             )
 
             with mock.patch.multiple(

--- a/crate_anon/conftest.py
+++ b/crate_anon/conftest.py
@@ -96,6 +96,15 @@ def pytest_addoption(parser: "Parser") -> None:
     )
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    if config.option.create_db:
+        message = (
+            "--create-db is a pytest-django option which is not "
+            "currently necessary. Did you mean --create-test-db?"
+        )
+        pytest.exit(message)
+
+
 # noinspection PyUnusedLocal
 def set_sqlite_pragma(
     dbapi_connection: "Connection",

--- a/crate_anon/integration_tests/sqlserver.Dockerfile
+++ b/crate_anon/integration_tests/sqlserver.Dockerfile
@@ -160,9 +160,10 @@ RUN apt-get update \
         iputils-ping \
         netcat \
     && curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc \
+    && curl https://packages.microsoft.com/config/ubuntu/22.04/mssql-server-2022.list | tee /etc/apt/sources.list.d/mssql-server.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        mssql-tools18 unixodbc-dev \
+        mssql-tools18 mssql-server-fts unixodbc-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     \

--- a/crate_anon/integration_tests/sqlserver.Dockerfile
+++ b/crate_anon/integration_tests/sqlserver.Dockerfile
@@ -105,8 +105,9 @@ USE [${DB_TEST}];\n\
 CREATE USER [${DB_TEST_USER}] FOR LOGIN [${DB_TEST_USER}];\n\
 EXEC sp_addrolemember 'db_owner', '${DB_TEST_USER}';\n\
 GO\n\
-\n\
+CREATE FULLTEXT CATALOG test_catalog AS DEFAULT;\n\
 GO\n\
+\n\
 "
 
 ARG STARTUP_SCRIPT_CONTENTS="#!bin/bash\n\

--- a/crate_anon/integration_tests/sqlserver.Dockerfile
+++ b/crate_anon/integration_tests/sqlserver.Dockerfile
@@ -89,6 +89,8 @@ EXEC sp_addrolemember 'db_owner', '${DB_PRIVUSER_USER}';\n\
 CREATE USER [${DB_RESEARCHER_USER}] FOR LOGIN [${DB_RESEARCHER_USER}];\n\
 EXEC sp_addrolemember 'db_datareader', '${DB_RESEARCHER_USER}';\n\
 GO\n\
+CREATE FULLTEXT CATALOG anon_catalog AS DEFAULT;\n\
+GO\n\
 \n\
 CREATE DATABASE [${DB_NLP}];\n\
 GO\n\

--- a/crate_anon/testing/__init__.py
+++ b/crate_anon/testing/__init__.py
@@ -28,6 +28,6 @@ crate_anon/testing/__init__.py
 from sqlalchemy import MetaData
 from sqlalchemy.orm import declarative_base
 
-
-metadata = MetaData()
-Base = declarative_base(metadata=metadata)
+# Access this through Base.metadata
+_metadata = MetaData()
+Base = declarative_base(metadata=_metadata)

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ INSTALL_REQUIRES = [
     "appdirs==1.4.4",  # where to store some temporary data
     "arrow==0.15.7",  # [pin exact version from cardinal_pythonlib]
     "beautifulsoup4==4.9.1",  # [pin exact version from cardinal_pythonlib]
-    "cardinal_pythonlib==1.1.25",  # RNC libraries
+    "cardinal_pythonlib @ git+https://github.com/RudolfCardinal/pythonlib@809e65f49de05cc101150a38bddb94f198b009ec#egg=cardinal_pythonlib==1.1.25.1",  # RNC libraries  # noqa: E501
     "cairosvg==2.7.0",  # work with SVG files
     "celery==5.2.3",  # back-end scheduling
     "chardet==3.0.4",  # character encoding detection for cardinal_pythonlib

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ INSTALL_REQUIRES = [
     "appdirs==1.4.4",  # where to store some temporary data
     "arrow==0.15.7",  # [pin exact version from cardinal_pythonlib]
     "beautifulsoup4==4.9.1",  # [pin exact version from cardinal_pythonlib]
-    "cardinal_pythonlib @ git+https://github.com/RudolfCardinal/pythonlib@809e65f49de05cc101150a38bddb94f198b009ec#egg=cardinal_pythonlib==1.1.25.1",  # RNC libraries  # noqa: E501
+    "cardinal_pythonlib==1.1.26",  # RNC libraries
     "cairosvg==2.7.0",  # work with SVG files
     "celery==5.2.3",  # back-end scheduling
     "chardet==3.0.4",  # character encoding detection for cardinal_pythonlib


### PR DESCRIPTION
The actual fix is in https://github.com/RudolfCardinal/pythonlib/pull/19. Here we upgrade pythonlib and add tests for full index creation on MySQL and SQL Server. 

I've added support for full text index in the SQL Server Dockerfile. The `mssql-server-fts `package seems to be pulling in `mssql-server`, which is slow and seems unnecessary. It might be that the base docker image bypasses the package management system.

I've also made pytest abort because I forget to pass in `--create-db` instead of `--create-test-db`. Confusingly I added `--create-db` to CamCOPS to mimic the behaviour of pytest-django. With CRATE we have pytest-django already (though we don't currently make use of Django database-level testing) so we have to call the option something else. We should probably make CamCOPS and CRATE consistent with each other.