### PR TITLE
Fix TypeError when generating SystmOne data dictionary

### DIFF
--- a/crate_anon/preprocess/systmone_ddgen.py
+++ b/crate_anon/preprocess/systmone_ddgen.py
@@ -1776,13 +1776,13 @@ def core_columnname(
 
 
 def contextual_columnname(
-    tablename_core: str, columname_core: str, to_context: SystmOneContext
+    tablename_core: str, columnname_core: str, to_context: SystmOneContext
 ) -> str:
     """
     Translates a "core" column name to its contextual variant, if applicable.
     """
     xlate = CORE_TO_CONTEXT_COLUMN_TRANSLATIONS[to_context]
-    return xlate.get((tablename_core, columname_core)) or columname_core
+    return xlate.get((tablename_core, columnname_core)) or columnname_core
 
 
 # =============================================================================

--- a/crate_anon/preprocess/systmone_ddgen.py
+++ b/crate_anon/preprocess/systmone_ddgen.py
@@ -1790,7 +1790,7 @@ def contextual_columnname(
 # =============================================================================
 
 
-def join_comments(*comments) -> str:
+def join_comments(comments: List[str]) -> str:
     """
     Joins comment elements, skipping any blanks.
     """
@@ -2624,7 +2624,9 @@ class TableCommentWorking:
             if ddr.is_table_comment:
                 # This DDR is itself the table comment. Modify it.
                 if self.append_comments:
-                    ddr.comment = join_comments(ddr.comment, s1_table_comment)
+                    ddr.comment = join_comments(
+                        [ddr.comment, s1_table_comment]
+                    )
                 else:
                     ddr.comment = s1_table_comment
             return
@@ -2725,7 +2727,7 @@ def annotate_systmone_dd_row(
         # If we have no new comment, leave the old one alone.
         if spec_comment:
             if append_comments:
-                ddr.comment = join_comments(ddr.comment, spec_comment)
+                ddr.comment = join_comments([ddr.comment, spec_comment])
             else:
                 ddr.comment = spec_comment
 
@@ -2788,6 +2790,7 @@ def modify_dd_for_systmone(
     table_comment_working = TableCommentWorking(
         dd=dd,
         specifications=specs,
+        append_comments=append_comments,
         allow_unprefixed_tables=allow_unprefixed_tables,
     )
     for ddr in dd.rows:

--- a/crate_anon/preprocess/tests/systmone_ddgen_tests.py
+++ b/crate_anon/preprocess/tests/systmone_ddgen_tests.py
@@ -31,17 +31,27 @@ Unit testing.
 # Imports
 # =============================================================================
 
-from unittest import TestCase
+import csv
+from tempfile import NamedTemporaryFile
+from typing import List, TYPE_CHECKING
+from unittest import mock, TestCase
 
+from crate_anon.anonymise.dd import DataDictionary
+from crate_anon.anonymise.ddr import DataDictionaryRow
 from crate_anon.preprocess.systmone_ddgen import (
     core_tablename,
     eq,
     eq_re,
     is_free_text,
     is_in_re,
+    modify_dd_for_systmone,
     OMIT_AND_IGNORE_TABLES_REGEX,
     SystmOneContext,
+    SystmOneSRESpecRow,
 )
+
+if TYPE_CHECKING:
+    from crate_anon.anonymise.config import Config
 
 
 # =============================================================================
@@ -89,4 +99,218 @@ class SystmOneDDGenTests(TestCase):
         # Not even in CPFT:
         self.assertFalse(
             is_free_text("FreeText_Honos_Scoring_Answers", "FreeText", cpft)
+        )
+
+
+class SystmOneDDGenTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.src_spec_row_dict = dict(
+            TableName="",
+            TableDescription="",
+            ColumnName="",
+            ColumnDescription="",
+            ColumnDataType="",
+            ColumnLength=0,
+            DateDefining="Yes",
+            ColumnOrdinal=0,
+            LinkedTable="",
+            LinkedColumn1="",
+            LinkedColumn2="",
+        )
+
+        self.context = SystmOneContext.CPFT_DW
+
+
+class SystmOneSRESpecRowTests(SystmOneDDGenTestCase):
+    def test_comment_has_table_and_column_descriptions(self) -> None:
+        self.src_spec_row_dict["TableDescription"] = "table_description"
+        self.src_spec_row_dict["ColumnDescription"] = "column_description"
+
+        row = SystmOneSRESpecRow(self.src_spec_row_dict)
+
+        self.assertEqual(
+            row.comment(self.context),
+            "TABLE: table_description // COLUMN: column_description",
+        )
+
+    def test_description_has_translated_table_name_column_name_and_comments(
+        self,
+    ) -> None:
+        self.src_spec_row_dict["TableName"] = "SRPatient"
+        self.src_spec_row_dict["ColumnName"] = "IDPatient"
+        self.src_spec_row_dict["TableDescription"] = "table_description"
+        self.src_spec_row_dict["ColumnDescription"] = "column_description"
+
+        row = SystmOneSRESpecRow(self.src_spec_row_dict)
+
+        description = row.description(self.context)
+        self.assertEqual(
+            description,
+            (
+                "S1_Patient.IDPatient // "
+                "TABLE: table_description // "
+                "COLUMN: column_description"
+            ),
+        )
+
+
+class TestDataDictionary(DataDictionary):
+    def __init__(
+        self, config: "Config", rows: List[DataDictionaryRow]
+    ) -> None:
+        super().__init__(config)
+
+        self.rows = rows
+
+
+class ModifyDDForSystmOneTests(SystmOneDDGenTestCase):
+    def test_table_comments_from_spec_added_to_data_dictionary(self) -> None:
+        mock_config = mock.Mock()
+
+        dd_row_1 = DataDictionaryRow(mock_config)
+        dd_row_1.src_db = "Source"
+        dd_row_1.src_table = "S1_Patient"
+        dd_row_1.src_field = "IDPatient"
+        dd_row_1.comment = "IDPatient comment"
+
+        dd_row_2 = DataDictionaryRow(mock_config)
+        dd_row_2.src_db = "Source"
+        dd_row_2.src_table = "S1_Patient"
+        dd_row_2.src_field = "NHSNumber"
+        dd_row_2.comment = "NHSNumber comment"
+
+        dd = TestDataDictionary(mock_config, [dd_row_1, dd_row_2])
+
+        context = SystmOneContext.CPFT_DW
+        with NamedTemporaryFile(delete=False, mode="w") as f:
+            fieldnames = self.src_spec_row_dict.keys()
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+
+            spec_row_1 = self.src_spec_row_dict.copy()
+            spec_row_1.update(
+                TableName="SRPatient",
+                ColumnName="IDPatient",
+                TableDescription="SRPatient description from spec",
+                ColumnDescription="IDPatient description from spec",
+            )
+
+            spec_row_2 = self.src_spec_row_dict.copy()
+            spec_row_2.update(
+                TableName="SRPatient",
+                ColumnName="NHSNumber",
+                TableDescription="SRPatient description from spec",
+                ColumnDescription="NHSNumber description from spec",
+            )
+
+            writer.writerow(spec_row_1)
+            writer.writerow(spec_row_2)
+
+        with open(f.name, mode="r") as f:
+            modify_dd_for_systmone(
+                dd, context, sre_spec_csv_filename=f.name, append_comments=True
+            )
+
+        self.assertEqual(len(dd.rows), 3)
+
+        # Comment row is sorted to the top
+        self.assertEqual(dd.rows[0].comment, "SRPatient description from spec")
+        self.assertEqual(
+            dd.rows[1].comment,
+            (
+                "IDPatient comment // "
+                "TABLE: SRPatient description from spec // "
+                "COLUMN: IDPatient description from spec"
+            ),
+        )
+
+        self.assertEqual(
+            dd.rows[2].comment,
+            (
+                "NHSNumber comment // "
+                "TABLE: SRPatient description from spec // "
+                "COLUMN: NHSNumber description from spec"
+            ),
+        )
+
+    def test_ddr_existing_table_comment_appended_with_spec_description(
+        self,
+    ) -> None:
+        mock_config = mock.Mock()
+
+        dd_row_1 = DataDictionaryRow(mock_config)
+        dd_row_1.src_db = "Source"
+        dd_row_1.src_table = "S1_Patient"
+        dd_row_1.src_field = "IDPatient"
+        dd_row_1.comment = "IDPatient comment"
+
+        dd_row_2 = DataDictionaryRow(mock_config)
+        dd_row_2.src_db = "Source"
+        dd_row_2.src_table = "S1_Patient"
+        dd_row_2.src_field = "NHSNumber"
+        dd_row_2.comment = "NHSNumber comment"
+
+        dd_row_3 = DataDictionaryRow(mock_config)
+        dd_row_3.src_db = "Source"
+        dd_row_3.src_table = "S1_Patient"
+        dd_row_3.src_field = ""
+        dd_row_3.comment = "Existing table comment"
+
+        dd = TestDataDictionary(mock_config, [dd_row_1, dd_row_2, dd_row_3])
+
+        context = SystmOneContext.CPFT_DW
+        with NamedTemporaryFile(delete=False, mode="w") as f:
+            fieldnames = self.src_spec_row_dict.keys()
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+
+            spec_row_1 = self.src_spec_row_dict.copy()
+            spec_row_1.update(
+                TableName="SRPatient",
+                ColumnName="IDPatient",
+                TableDescription="SRPatient description from spec",
+                ColumnDescription="IDPatient description from spec",
+            )
+
+            spec_row_2 = self.src_spec_row_dict.copy()
+            spec_row_2.update(
+                TableName="SRPatient",
+                ColumnName="NHSNumber",
+                TableDescription="SRPatient description from spec",
+                ColumnDescription="NHSNumber description from spec",
+            )
+
+            writer.writerow(spec_row_1)
+            writer.writerow(spec_row_2)
+
+        with open(f.name, mode="r") as f:
+            modify_dd_for_systmone(
+                dd, context, sre_spec_csv_filename=f.name, append_comments=True
+            )
+
+        self.assertEqual(len(dd.rows), 3)
+
+        # Comment row is sorted to the top
+        self.assertEqual(
+            dd.rows[0].comment,
+            "Existing table comment // SRPatient description from spec",
+        )
+        self.assertEqual(
+            dd.rows[1].comment,
+            (
+                "IDPatient comment // "
+                "TABLE: SRPatient description from spec // "
+                "COLUMN: IDPatient description from spec"
+            ),
+        )
+
+        self.assertEqual(
+            dd.rows[2].comment,
+            (
+                "NHSNumber comment // "
+                "TABLE: SRPatient description from spec // "
+                "COLUMN: NHSNumber description from spec"
+            ),
         )

--- a/crate_anon/preprocess/tests/systmone_ddgen_tests.py
+++ b/crate_anon/preprocess/tests/systmone_ddgen_tests.py
@@ -125,23 +125,31 @@ class SystmOneDDGenTestCase(TestCase):
 
 class SystmOneSRESpecRowTests(SystmOneDDGenTestCase):
     def test_comment_has_table_and_column_descriptions(self) -> None:
-        self.src_spec_row_dict["TableDescription"] = "table_description"
-        self.src_spec_row_dict["ColumnDescription"] = "column_description"
-
+        self.src_spec_row_dict.update(
+            TableName="SRPatient",
+            ColumnName="IDPatient",
+            TableDescription="SRPatient description from spec",
+            ColumnDescription="IDPatient description from spec",
+        )
         row = SystmOneSRESpecRow(self.src_spec_row_dict)
 
         self.assertEqual(
             row.comment(self.context),
-            "TABLE: table_description // COLUMN: column_description",
+            (
+                "TABLE: SRPatient description from spec // "
+                "COLUMN: IDPatient description from spec"
+            ),
         )
 
-    def test_description_has_translated_table_name_column_name_and_comments(
+    def test_description_has_translated_table_column_and_spec_descriptions(
         self,
     ) -> None:
-        self.src_spec_row_dict["TableName"] = "SRPatient"
-        self.src_spec_row_dict["ColumnName"] = "IDPatient"
-        self.src_spec_row_dict["TableDescription"] = "table_description"
-        self.src_spec_row_dict["ColumnDescription"] = "column_description"
+        self.src_spec_row_dict.update(
+            TableName="SRPatient",
+            ColumnName="IDPatient",
+            TableDescription="SRPatient description from spec",
+            ColumnDescription="IDPatient description from spec",
+        )
 
         row = SystmOneSRESpecRow(self.src_spec_row_dict)
 
@@ -150,8 +158,8 @@ class SystmOneSRESpecRowTests(SystmOneDDGenTestCase):
             description,
             (
                 "S1_Patient.IDPatient // "
-                "TABLE: table_description // "
-                "COLUMN: column_description"
+                "TABLE: SRPatient description from spec // "
+                "COLUMN: IDPatient description from spec"
             ),
         )
 


### PR DESCRIPTION
@RudolfCardinal There are calls to `join_comments()` which in some places use a list and in other places a variable argument list. I've fixed these so that a list is passed every time and this goes straight through to the filter function. Is this what you intended?

Also when writing tests for the three calls to `join_comments()` I found that https://github.com/ucam-department-of-psychiatry/crate/blob/systmone-ddgen-comments-fix/crate_anon/preprocess/systmone_ddgen.py#L2627 would never be made because `TableCommentWorking()` was not being passed the `append_comments` flag. I've put this in and note that it would be unusual for `append_comments` to be anything other than the default of `False` with the SRE specification. Was this the right thing to do?

