### PR TITLE
Stop GitHub thinking this is a JavaScript project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+crate_anon/crateweb/specimen_archives/static/plotly-*.js linguist-vendored


### PR DESCRIPTION
Tell GitHub to ignore Plotly when calculating language stats.