### PR TITLE
Add optional files to the demo database

### DIFF
--- a/crate_anon/anonymise/make_demo_database.py
+++ b/crate_anon/anonymise/make_demo_database.py
@@ -251,7 +251,7 @@ def main() -> None:
         "--with_files",
         action="store_true",
         default=False,
-        help="Include demo files (doc, pdf etc)",
+        help="Create a random docx, odt or pdf file for each patient",
     )
     parser.add_argument("--echo", action="store_true", help="Echo SQL")
 

--- a/crate_anon/anonymise/make_demo_database.py
+++ b/crate_anon/anonymise/make_demo_database.py
@@ -65,6 +65,7 @@ from crate_anon.anonymise.constants import CHARSET
 from crate_anon.common.constants import EnvVar
 from crate_anon.testing import Base
 from crate_anon.testing.factories import (
+    DemoFilenameDocFactory,
     DemoPatientFactory,
     set_sqlalchemy_session_on_all_factories,
 )
@@ -129,6 +130,7 @@ def mk_demo_database(
     n_patients: int,
     notes_per_patient: int,
     words_per_note: int,
+    with_files: bool = False,
     echo: bool = False,
 ) -> None:
     # 0. Announce intentions
@@ -136,7 +138,8 @@ def mk_demo_database(
     log.info(
         f"n_patients={n_patients}, "
         f"notes_per_patient={notes_per_patient}, "
-        f"words_per_note={words_per_note}"
+        f"words_per_note={words_per_note}, "
+        f"with_files={with_files}"
     )
 
     # 1. Open database
@@ -180,6 +183,9 @@ def mk_demo_database(
         ):
             num_words = len(note.note.split())
             total_words += num_words
+
+        if with_files:
+            DemoFilenameDocFactory(patient=patient)
 
     session.commit()
     # 5. Report size
@@ -241,24 +247,12 @@ def main() -> None:
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Be verbose"
     )
-    # Not currently used -- todo: add back binaries to demo database?
-    # parser.add_argument(
-    #     "--doctest_doc", default=DEFAULT_DOCTEST_DOC,
-    #     help="Test file for .DOC"
-    # )
-    # parser.add_argument(
-    #     "--doctest_docx",
-    #     default=DEFAULT_DOCTEST_DOCX,
-    #     help="Test file for .DOCX",
-    # )
-    # parser.add_argument(
-    #     "--doctest_odt", default=DEFAULT_DOCTEST_ODT,
-    #     help="Test file for .ODT"
-    # )
-    # parser.add_argument(
-    #     "--doctest_pdf", default=DEFAULT_DOCTEST_PDF,
-    #     help="Test file for .PDF"
-    # )
+    parser.add_argument(
+        "--with_files",
+        action="store_true",
+        default=False,
+        help="Include demo files (doc, pdf etc)",
+    )
     parser.add_argument("--echo", action="store_true", help="Echo SQL")
 
     args = parser.parse_args()
@@ -292,6 +286,7 @@ def main() -> None:
         n_patients=n_patients,
         notes_per_patient=notes_per_patient,
         words_per_note=words_per_note,
+        with_files=args.with_files,
         echo=args.echo,
     )
 

--- a/crate_anon/testing/factories.py
+++ b/crate_anon/testing/factories.py
@@ -35,7 +35,7 @@ import factory
 import factory.random
 from faker import Faker
 
-from crate_anon.testing.models import EnumColours, Note, Patient
+from crate_anon.testing.models import EnumColours, FilenameDoc, Note, Patient
 from crate_anon.testing.providers import register_all_providers
 
 if TYPE_CHECKING:
@@ -150,7 +150,7 @@ class DemoNoteFactory(DemoFactory):
 
     @factory.lazy_attribute
     def note(obj: "Resolver") -> str:
-        # You get Lorem ipsum with en_GB.
+        # Use en_US because you get Lorem ipsum with en_GB.
         pad_paragraph = Fake.en_us.paragraph(
             nb_sentences=obj.words_per_note / 2,  # way more than we need
         )
@@ -163,6 +163,37 @@ class DemoNoteFactory(DemoFactory):
             nhs_number=obj.patient.nhsnum,
             patient_id=obj.patient.patient_id,
             note_datetime=obj.note_datetime,
+            relation_name=obj.patient.related_patient_name,
+            relation_relationship=obj.patient.related_patient_relationship,
+            words_per_note=obj.words_per_note,
+            pad_paragraph=pad_paragraph,
+        )
+
+
+class DemoFilenameDocFactory(DemoFactory):
+    class Meta:
+        model = FilenameDoc
+
+    class Params:
+        words_per_note = 100
+
+    file_datetime = factory.LazyFunction(Fake.en_gb.incrementing_date)
+
+    @factory.lazy_attribute
+    def filename(obj: "Resolver") -> str:
+        # Use en_US because you get Lorem ipsum with en_GB.
+        pad_paragraph = Fake.en_us.paragraph(
+            nb_sentences=obj.words_per_note / 2,  # way more than we need
+        )
+
+        return Fake.en_gb.patient_filename(
+            forename=obj.patient.forename,
+            surname=obj.patient.surname,
+            sex=obj.patient.sex,
+            dob=obj.patient.dob,
+            nhs_number=obj.patient.nhsnum,
+            patient_id=obj.patient.patient_id,
+            note_datetime=obj.file_datetime,
             relation_name=obj.patient.related_patient_name,
             relation_relationship=obj.patient.related_patient_relationship,
             words_per_note=obj.words_per_note,

--- a/crate_anon/testing/factories.py
+++ b/crate_anon/testing/factories.py
@@ -174,17 +174,12 @@ class DemoFilenameDocFactory(DemoFactory):
     class Meta:
         model = FilenameDoc
 
-    class Params:
-        words_per_note = 100
-
     file_datetime = factory.LazyFunction(Fake.en_gb.incrementing_date)
 
     @factory.lazy_attribute
     def filename(obj: "Resolver") -> str:
         # Use en_US because you get Lorem ipsum with en_GB.
-        pad_paragraph = Fake.en_us.paragraph(
-            nb_sentences=obj.words_per_note / 2,  # way more than we need
-        )
+        pad_paragraph = Fake.en_us.paragraph(nb_sentences=50)
 
         return Fake.en_gb.patient_filename(
             forename=obj.patient.forename,
@@ -193,9 +188,5 @@ class DemoFilenameDocFactory(DemoFactory):
             dob=obj.patient.dob,
             nhs_number=obj.patient.nhsnum,
             patient_id=obj.patient.patient_id,
-            note_datetime=obj.file_datetime,
-            relation_name=obj.patient.related_patient_name,
-            relation_relationship=obj.patient.related_patient_relationship,
-            words_per_note=obj.words_per_note,
             pad_paragraph=pad_paragraph,
         )

--- a/docs/source/ancillary/_crate_make_demo_database_help.txt
+++ b/docs/source/ancillary/_crate_make_demo_database_help.txt
@@ -1,4 +1,5 @@
-USAGE: crate_make_demo_database [-h] [--size {0,1,2,3}] [--verbose] [--echo]
+USAGE: crate_make_demo_database [-h] [--size {0,1,2,3}] [--verbose]
+                                [--with_files] [--echo]
                                 url
 
 POSITIONAL ARGUMENTS:
@@ -13,4 +14,5 @@ OPTIONS:
   --size {0,1,2,3}  Make tiny (0), small (1), medium (2), or large (3)
                     database (default: 0)
   --verbose, -v     Be verbose (default: False)
+  --with_files      Include demo files (doc, pdf etc) (default: False)
   --echo            Echo SQL (default: False)

--- a/docs/source/ancillary/_crate_make_demo_database_help.txt
+++ b/docs/source/ancillary/_crate_make_demo_database_help.txt
@@ -14,5 +14,6 @@ OPTIONS:
   --size {0,1,2,3}  Make tiny (0), small (1), medium (2), or large (3)
                     database (default: 0)
   --verbose, -v     Be verbose (default: False)
-  --with_files      Include demo files (doc, pdf etc) (default: False)
+  --with_files      Create a random docx, odt or pdf file for each patient
+                    (default: False)
   --echo            Echo SQL (default: False)

--- a/github_action_scripts/python_checks.sh
+++ b/github_action_scripts/python_checks.sh
@@ -18,12 +18,10 @@ echo checking packages for vulnerabilities
 # All of these vulnerabilities look either harmless or very low risk
 # 51668 sqlalchemy fix in 2.0 beta, we don't log Engine.URL()
 #       https://github.com/sqlalchemy/sqlalchemy/issues/8567
-# 52495 setuptools fix in 65.5.1, we'll be careful not to
-#       install malicious packages.
 # 67599 pip. Disputed and only relevant if using --extra-index-url,
 #       which we're not.
 # 70612 jinja2. The maintainer and multiple third parties
 #       believe that this vulnerability isn't valid because
 #       users shouldn't use untrusted templates without
 #       sandboxing.
-${SAFETY} check --full-report --ignore=51668 --ignore=52495 --ignore=67599 --ignore=70612
+${SAFETY} check --full-report --ignore=51668 --ignore=67599 --ignore=70612

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ INSTALL_REQUIRES = [
     "Pillow==10.3.0",  # image processing; import as PIL (Python Imaging Library)  # noqa: E501
     "pdfkit==0.6.1",  # interface to wkhtmltopdf
     "prettytable==3.2.0",  # pretty formating of text-based tables
-    "psutil==5.7.2",  # process management
+    "psutil==6.0.0",  # process management
     "pyexcel-ods==0.6.0",  # for reading/writing ODS files
     "pyexcel-xlsx==0.6.0",  # for writing XLSX files (using openpyxl)
     "pygments==2.15.0",  # syntax highlighting

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ INSTALL_REQUIRES = [
     # -------------------------------------------------------------------------
     # Packages for cloud NLP:
     # -------------------------------------------------------------------------
-    "bcrypt==3.1.7",  # bcrypt encryption
+    "bcrypt==3.2.2",  # bcrypt encryption
     "cryptography==43.0.1",  # cryptography library
     # "mysqlclient",  # database access
     "paste==3.4.2",  # middleware; https://github.com/cdent/paste/
@@ -147,6 +147,7 @@ INSTALL_REQUIRES = [
     "flake8==5.0.4",  # code checks, keep in sync with .pre-commit-config.yaml
     "docutils==0.19",
     "mistune<2.0.0",  # API documentation, 2.0.0 not compatible
+    "paramiko==3.4.1",  # Python implementation of the SSHv2 protocol, required by faker-file  # noqa: E501
     "pre-commit==2.20.0",  # development only, various sanity checks on code
     "pytest==8.1.1",  # automatic testing
     "pytest-django==4.5.2",  # automatic testing

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ INSTALL_REQUIRES = [
     "beautifulsoup4==4.9.1",  # [pin exact version from cardinal_pythonlib]
     "cardinal_pythonlib==1.1.27",  # RNC libraries
     "cairosvg==2.7.0",  # work with SVG files
-    "celery==5.2.3",  # back-end scheduling
+    "celery==5.2.7",  # back-end scheduling
     "chardet==3.0.4",  # character encoding detection for cardinal_pythonlib
     "cherrypy==18.6.0",  # Cross-platform web server
     "colorlog==4.1.0",  # colour in logs

--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ INSTALL_REQUIRES = [
     "black==24.3.0",  # auto code formatter, keep in sync with .pre-commit-config.yaml  # noqa: E501
     "factory_boy==3.3.0",  # easier test data creation
     "faker==13.3.1",  # test data creation
+    "faker-file[common]==0.17.13",  # test file creation
     "flake8==5.0.4",  # code checks, keep in sync with .pre-commit-config.yaml
     "docutils==0.19",
     "mistune<2.0.0",  # API documentation, 2.0.0 not compatible


### PR DESCRIPTION
I've added a new `with_files` option to `crate_make_demo_database`, which if selected will create a random docx, odt or pdf file for each patient with identifiable data.

This uses [faker-file](https://github.com/barseghyanartur/faker-file), which is quite new but seems to do most of what we want (there is no support for old `.doc` files currently).

It would not be too difficult to add support for BlobDoc too.

