### PR TITLE
Stop Docker image ballooning in size when USER_ID is large

### DIFF
--- a/docker/dockerfiles/crate.Dockerfile
+++ b/docker/dockerfiles/crate.Dockerfile
@@ -46,7 +46,11 @@ ARG USER_ID
 ARG GROUP_ID
 
 RUN addgroup --gid $GROUP_ID crate
-RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID crate
+
+# The --no-log-init is necessary to prevent the image ballooning in size
+# when USER_ID is large
+# See https://github.com/moby/moby/issues/5419
+RUN useradd --no-log-init --uid $USER_ID --gid $GROUP_ID crate
 
 FROM crate-build-1-user AS crate-build-2-files
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1691,11 +1691,15 @@ Changes
 - Fix the data dictionary generator to allow column names with valid but unusual
   characters in the source database. Convert any unusual characters to ASCII in
   the destination database.
-  
+
 - Update ``crate_postcodes`` to support the November 2024 ONSPD in full. Offer
   partial support for ONSPD lookup tables in earlier/future versions by not
   failing when there is a mismatch between the created database tables and the
   ONSPD spreadsheet files.
+
+- Workaround a problem with Docker's handling of large sparse files, which
+  resulted in a very large Docker image if the ID of the user creating the image
+  was large.
 
 
 To do


### PR DESCRIPTION
When a user is added with `adduser` in the Dockerfile, a sparse file `/var/log/lastlog` is created whose size is proportional to the user ID. Docker's inability to handle sparse files results in a very large image. With UIDs from Active Directory like 1885580785, this results in a 1.23TB image.

I've implemented one of the workarounds listed in https://github.com/moby/moby/issues/5419. One alternative is to set `LASTLOG_UID_MAX` to `UID_MAX` in `/etc/login.defs`. Another is to delete `/var/log/lastlog` in the same RUN command to ensure it all happens in the same layer.


