### PR TITLE
Fix duplicate column error during anonymisation if table exists with 'trid' already present

### DIFF
--- a/crate_anon/anonymise/dd.py
+++ b/crate_anon/anonymise/dd.py
@@ -1617,7 +1617,7 @@ class DataDictionary:
         pid_found = False
         rows_include_mrid_with_expected_name = False
         columns = []  # type: List[Column]
-        extra_kwargs = {}  # type: Dict[str, Any]
+        extra_kwargs = dict(extend_existing=True)  # type: Dict[str, Any]
         for ddr in self.get_rows_for_dest_table(
             tablename, skip_table_comments=False
         ):


### PR DESCRIPTION
Seen when anonymising SystmOne on the CPFT server. I imagine the same error would be seen for any of the other columns added here. 