### PR TITLE
More helpful error message when patient ID missing from data dictionary

### DIFF
--- a/crate_anon/anonymise/anonymise.py
+++ b/crate_anon/anonymise/anonymise.py
@@ -1045,6 +1045,11 @@ def count_rows(
     query = select(func.count()).select_from(table(sourcetable))
     if pid is not None:
         pidcol_name = config.dd.get_pid_name(dbname, sourcetable)
+        if not pidcol_name:
+            raise ValueError(
+                "No row in the data dictionary provides primary PID "
+                f"information for db:{dbname}, table: {sourcetable}"
+            )
         query = query.where(column(pidcol_name) == pid)
     return session.execute(query).scalar()
 


### PR DESCRIPTION
Seen when anonymising SystmOne data on the CPFT server. The data dictionary has a master PID for S1_ClinicalOutcome_PairedHoNOS but no PatientID.

Ideally we would trap this at the validation stage but for now this is an improvement on the error generated by SQL Alchemy:

`Cannot compile Column object until its 'name' is assigned.`