### PR TITLE
Update the pre-commit workflow to use later Ubuntu

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -11,12 +11,12 @@ on:
             - .pre-commit-config.yaml
 jobs:
     precommit-checks:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-python@v5
               with:
-                  python-version: 3.9
+                  python-version: "3.10"
             - name: Pre-commit checks
               run: |
                   set -euxo pipefail


### PR DESCRIPTION
GitHub are shortly going to remove support for Ubuntu 20.04 workflows